### PR TITLE
Add use_scopes toggle for issue #3552

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -26,8 +26,7 @@ from fastapi.concurrency import (
 from fastapi.dependencies.models import Dependant, SecurityRequirement
 from fastapi.logger import logger
 from fastapi.security.base import SecurityBase
-from fastapi.security.oauth2 import OAuth2, SecurityScopes
-from fastapi.security.open_id_connect_url import OpenIdConnect
+from fastapi.security.oauth2 import SecurityScopes
 from fastapi.utils import create_response_field, get_path_param_names
 from pydantic import BaseModel, create_model
 from pydantic.error_wrappers import ErrorWrapper
@@ -145,7 +144,7 @@ def get_sub_dependant(
         security_scopes.extend(dependency_scopes)
     if isinstance(dependency, SecurityBase):
         use_scopes: List[str] = []
-        if isinstance(dependency, (OAuth2, OpenIdConnect)):
+        if dependency.use_scopes:
             use_scopes = security_scopes
         security_requirement = SecurityRequirement(
             security_scheme=dependency, scopes=use_scopes

--- a/fastapi/security/base.py
+++ b/fastapi/security/base.py
@@ -4,3 +4,4 @@ from fastapi.openapi.models import SecurityBase as SecurityBaseModel
 class SecurityBase:
     model: SecurityBaseModel
     scheme_name: str
+    use_scopes: bool = False

--- a/fastapi/security/http.py
+++ b/fastapi/security/http.py
@@ -24,11 +24,17 @@ class HTTPAuthorizationCredentials(BaseModel):
 
 class HTTPBase(SecurityBase):
     def __init__(
-        self, *, scheme: str, scheme_name: Optional[str] = None, auto_error: bool = True
+        self,
+        *,
+        scheme: str,
+        scheme_name: Optional[str] = None,
+        auto_error: bool = True,
+        use_scopes: bool = False,
     ):
         self.model = HTTPBaseModel(scheme=scheme)
         self.scheme_name = scheme_name or self.__class__.__name__
         self.auto_error = auto_error
+        self.use_scopes = use_scopes
 
     async def __call__(
         self, request: Request
@@ -98,10 +104,12 @@ class HTTPBearer(HTTPBase):
         bearerFormat: Optional[str] = None,
         scheme_name: Optional[str] = None,
         auto_error: bool = True,
+        use_scopes: bool = False,
     ):
         self.model = HTTPBearerModel(bearerFormat=bearerFormat)
         self.scheme_name = scheme_name or self.__class__.__name__
         self.auto_error = auto_error
+        self.use_scopes = use_scopes
 
     async def __call__(
         self, request: Request

--- a/fastapi/security/oauth2.py
+++ b/fastapi/security/oauth2.py
@@ -118,11 +118,12 @@ class OAuth2(SecurityBase):
         *,
         flows: Union[OAuthFlowsModel, Dict[str, Dict[str, Any]]] = OAuthFlowsModel(),
         scheme_name: Optional[str] = None,
-        auto_error: Optional[bool] = True
+        auto_error: Optional[bool] = True,
     ):
         self.model = OAuth2Model(flows=flows)
         self.scheme_name = scheme_name or self.__class__.__name__
         self.auto_error = auto_error
+        self.use_scopes = True
 
     async def __call__(self, request: Request) -> Optional[str]:
         authorization: str = request.headers.get("Authorization")

--- a/fastapi/security/open_id_connect_url.py
+++ b/fastapi/security/open_id_connect_url.py
@@ -18,6 +18,7 @@ class OpenIdConnect(SecurityBase):
         self.model = OpenIdConnectModel(openIdConnectUrl=openIdConnectUrl)
         self.scheme_name = scheme_name or self.__class__.__name__
         self.auto_error = auto_error
+        self.use_scopes = True
 
     async def __call__(self, request: Request) -> Optional[str]:
         authorization: str = request.headers.get("Authorization")


### PR DESCRIPTION
Add a `use_scopes` bool for SecurityBase subclasses. When true, display
scopes in generated OpenAPI.

On by default for OpenIdConnect and OAuth2 schemes.